### PR TITLE
update icon name

### DIFF
--- a/R/mod_reporting.R
+++ b/R/mod_reporting.R
@@ -20,7 +20,7 @@ mod_reporting_ui <- function(id){
                          value = "logs",
                          actionButton(ns("logs_refresh"),
                                       label = "",
-                                      icon = icon("refresh")) %>% 
+                                      icon = icon("sync")) %>% 
                            tagAppendAttributes(style = "float:right;"),
                          dataTableOutput(ns("report_logs")))
     )


### PR DESCRIPTION
should remove warning for fontawesome deprecation notice as reported here https://github.com/RE-QDA/requal/issues/40