### PR TITLE
Overlap efficiency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: requal
 Title: Shiny Application for Computer-assisted Qualitative Data Analysis 
-Version: 0.2.1
+Version: 0.2.2
 Authors@R: 
     c(
     person(given = "Radim",

--- a/R/mod_document_code_utils_document_code.R
+++ b/R/mod_document_code_utils_document_code.R
@@ -245,13 +245,16 @@ for (i in seq_along(vals)) {
     )
   }
 }
+
+if (nrow(res)) {
 prefinal <- res %>%
   dplyr::mutate(
     code_id = dplyr::lead(code_id),
     segment_end = dplyr::lead(segment_end)
   ) %>%
   dplyr::filter(code_id != "",
-                !is.na(code_id)) 
+                !is.na(code_id)) %>% 
+    dplyr::mutate(segment_id = 0:(dplyr::n()-1))  }else {res}
     
 
 }

--- a/R/mod_document_code_utils_document_code.R
+++ b/R/mod_document_code_utils_document_code.R
@@ -223,13 +223,13 @@ res <- dplyr::tibble(
 )
 
 for (i in seq_along(vals)) {
-  test <- raw_segments %>%
+  overlap_df <- raw_segments %>%
     dplyr::filter(vals[i] > segment_start & vals[i] <= segment_end)
   if (names(vals[i]) == "segment_start") {
     res <- dplyr::bind_rows(
       res,
       tibble::tibble(
-        code_id = paste0(sort(test$code_id), collapse = "+"),
+        code_id = paste0(sort(overlap_df$code_id), collapse = "+"),
         segment_start = vals[i],
         segment_end = vals[i] - 1
       )
@@ -238,9 +238,9 @@ for (i in seq_along(vals)) {
     res <- dplyr::bind_rows(
       res,
       tibble::tibble(
-        code_id = paste0(sort(test$code_id), collapse = "+"),
+        code_id = paste0(sort(overlap_df$code_id), collapse = "+"),
         segment_start = vals[i] + 1,
-        segment_end = min(test$segment_end)
+        segment_end = min(overlap_df$segment_end)
       )
     )
   }
@@ -254,7 +254,7 @@ prefinal <- res %>%
   ) %>%
   dplyr::filter(code_id != "",
                 !is.na(code_id)) %>% 
-    dplyr::mutate(segment_id = 0:(dplyr::n()-1))  }else {res}
+    dplyr::mutate(segment_id = 0:(dplyr::n()-1))  } else {res}
     
 
 }


### PR DESCRIPTION
- switching from df manipulation to a for loop as a primary overlap calculator
-  the function no longer relies on intersecting entire segments of characters, instead, its complexity grows only with the number of codes in the document, not their size
- there are huge performance improvements
- it proceeds algorithmically, pausing at each code break and looking back if any other code is also still valid at the given position
- from the previous solution, i carried over indexing of segments starting at 0 - not sure why it was done so in the first place, but it works, so i am not trying to fix it, maybe there was a good reason for that