### PR TITLE
Bugfix/log display error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: requal
 Title: Shiny Application for Computer-assisted Qualitative Data Analysis 
-Version: 0.2.2
+Version: 0.2.4
 Authors@R: 
     c(
     person(given = "Radim",

--- a/R/mod_about.R
+++ b/R/mod_about.R
@@ -17,7 +17,9 @@ mod_about_ui <- function(id){
     "ReQual CAQDAS"
     ), 
     
-    textOutput(ns("version")),
+    textOutput(ns("version_project")),
+    
+    textOutput(ns("version_package")),
     
     p(),
     
@@ -50,14 +52,19 @@ mod_about_server <- function(id, project){
           dplyr::pull(version) 
       }
     
-    output$version <- renderText({
+    output$version_project <- renderText({
       if (isTruthy(project()$active_project)) {
         paste0(
           "The current project was created with requal version ",
           read_version(project()$project_db,
-                       project()$active_project)
+                       project()$active_project), ". "
         )
       } else {""}
+    })
+    
+    output$version_package <- renderText({
+      paste0("The current version of requal package installed is ", 
+      packageVersion("requal"), ".")
     })
  
   })

--- a/R/mod_doc_manager.R
+++ b/R/mod_doc_manager.R
@@ -171,10 +171,11 @@ observeEvent(input$doc_add, {
     # document removal ----
     observeEvent(input$doc_remove, {
       
- 
-      delete_db_documents(project()$project_db, 
-                                      project()$active_project, 
-                                      input$doc_delete_list)
+      if(length(input$doc_delete_list)){
+        delete_db_documents(project()$project_db, 
+                            project()$active_project, 
+                            input$doc_delete_list)
+      }
       
       # update reactive value containing project documents
       doc_list(list_db_documents(project_db = project()$project_db,

--- a/R/mod_doc_manager.R
+++ b/R/mod_doc_manager.R
@@ -171,11 +171,12 @@ observeEvent(input$doc_add, {
     # document removal ----
     observeEvent(input$doc_remove, {
       
-      if(length(input$doc_delete_list)){
+     req(input$doc_delete_list)
+      
         delete_db_documents(project()$project_db, 
                             project()$active_project, 
                             input$doc_delete_list)
-      }
+      
       
       # update reactive value containing project documents
       doc_list(list_db_documents(project_db = project()$project_db,

--- a/R/mod_doc_manager_utils_doc_manager.R
+++ b/R/mod_doc_manager_utils_doc_manager.R
@@ -11,7 +11,9 @@ delete_db_documents <- function(project_db,
                    "DELETE from documents
                    WHERE doc_id IN (?)",
                    params = list(delete_doc_id))
-    log_delete_document_record(con, active_project, delete_doc_id)
+    if(length(delete_doc_id)){
+        log_delete_document_record(con, active_project, delete_doc_id)   
+    }
 }
 
 

--- a/R/mod_reporting.R
+++ b/R/mod_reporting.R
@@ -53,7 +53,7 @@ mod_reporting_server <- function(id, project){
     output$report_logs <- renderDataTable({
       req(logs_df())
       logs_df() %>% 
-        dplyr::mutate(payload = purrr::map_chr(.data$payload, parse_payload_json))
+        dplyr::mutate(detail = purrr::map_chr(.data$detail, possibly_parse_payload_json))
     })
     
 })}

--- a/R/mod_reporting_utils_reporting.R
+++ b/R/mod_reporting_utils_reporting.R
@@ -11,7 +11,7 @@ load_logs_for_reporting <- function(project_db,
         dplyr::filter(.data$project_id == as.integer(active_project)) %>%
         dplyr::select(.data$user,
                       .data$action, 
-                      .data$payload, 
+                      detail = .data$payload, 
                       .data$created_at) %>%
         dplyr::collect()
     
@@ -42,3 +42,4 @@ parse_payload_json <- function(x){
         paste0(., collapse = "; ")
 }
 
+possibly_parse_payload_json <- purrr::possibly(parse_payload_json, "")


### PR DESCRIPTION
Closes #50 and closes #47

The bug was caused by logging "Removing document" without selecting a document from the menu. 
Therefore, there was a log of event "delete document" without any content of the event. I fixed it by using `purrr::possibly` when parsing the log content and checking if there is a document to be deleted selected (and calling function `delete_db_documents` only if there is any selected).  