### PR TITLE
Bugfix/document refresh post merge

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: requal
 Title: Shiny Application for Computer-assisted Qualitative Data Analysis
-Version: 0.4.0
+Version: 0.4.1
 Authors@R:
     c(
      person(given = "Radim",

--- a/R/mod_document_code.R
+++ b/R/mod_document_code.R
@@ -137,6 +137,14 @@ segments_observer <- reactiveVal(0)
           )
         }
         
+        if (isTruthy(req(input$doc_selector))) {
+          text(load_doc_to_display(project()$active_project, 
+                                   project()$project_db, 
+                                   input$doc_selector, 
+                                   code_df$active_codebook,
+                                   ns=NS(id)))
+        }
+        
         purrr::pmap(
           list(
           code_df$active_codebook$code_id,
@@ -148,6 +156,7 @@ segments_observer <- reactiveVal(0)
                                   code_name = ..2,
                                   code_color = ..3)
         )
+        
         
       } else {
         ""


### PR DESCRIPTION
- when there is an active document opened, it will refresh after changes in the codebook, including merges
- known trade-off: active document is refreshed even if it does not contain any (changed) codes and also when new codes are created
- more sophisticated conditions and observers would need to be set up to prevent the inefficiency
- feel free not to merge