### PR TITLE
add user data to modules

### DIFF
--- a/R/app_server.R
+++ b/R/app_server.R
@@ -26,29 +26,29 @@ app_server <- function(input, output, session) {
 
   # documents  ----
   
-  documents <- mod_project_server("mod_project_ui_1", project_observer)
+  documents <- mod_project_server("mod_project_ui_1", project_observer, user)
   
   # codebook  ----
   
-  codebook <- mod_codebook_server("codebook_ui_1", project_observer)
+  codebook <- mod_codebook_server("codebook_ui_1", project_observer, user)
   
   # workdesk ----
  
-  segments_observer <- mod_document_code_server("document_code_ui_1", project_observer, codebook, documents)
+  segments_observer <- mod_document_code_server("document_code_ui_1", project_observer, user, codebook, documents)
   
   # analysis ----
   
-  segments_df <- mod_analysis_server("analysis_ui_1", project_observer, codebook, documents, segments_observer)
+  segments_df <- mod_analysis_server("analysis_ui_1", project_observer, user, codebook, documents, segments_observer)
 
   mod_download_handler_server("download_handler_ui_1", segments_df)
 
   # reporting
   
-  reporting <- mod_reporting_server("reporting_ui_1", project_observer)
+  reporting <- mod_reporting_server("reporting_ui_1", project_observer, user)
 
     # about -----
   
-  mod_about_server("about_ui_1", project_observer)
+  mod_about_server("about_ui_1", project_observer, user)
   
   # user
   user <- mod_user_server("user_ui_1", project_observer)

--- a/R/mod_about.R
+++ b/R/mod_about.R
@@ -36,7 +36,7 @@ mod_about_ui <- function(id){
 #' about Server Functions
 #'
 #' @noRd 
-mod_about_server <- function(id, project){
+mod_about_server <- function(id, project, user){
   moduleServer( id, function(input, output, session){
     ns <- session$ns
     

--- a/R/mod_analysis.R
+++ b/R/mod_analysis.R
@@ -43,7 +43,7 @@ mod_analysis_ui <- function(id) {
 #' analysis Server Functions
 #'
 #' @noRd
-mod_analysis_server <- function(id, project, codebook, documents, segments) {
+mod_analysis_server <- function(id, project, user, codebook, documents, segments) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
 

--- a/R/mod_codebook.R
+++ b/R/mod_codebook.R
@@ -31,7 +31,7 @@ mod_codebook_ui <- function(id) {
 #' codebook Server Functions
 #'
 #' @noRd
-mod_codebook_server <- function(id, project) {
+mod_codebook_server <- function(id, project, user) {
   moduleServer(id, function(input, output, session) {
     
     ns <- session$ns

--- a/R/mod_document_code.R
+++ b/R/mod_document_code.R
@@ -57,7 +57,7 @@ mod_document_code_ui <- function(id){
 #' document_code Server Functions
 #'
 #' @noRd 
-mod_document_code_server <- function(id, project, codebook, documents){
+mod_document_code_server <- function(id, project, user, codebook, documents){
   moduleServer( id, function(input, output, session){
     ns <- session$ns
     

--- a/R/mod_project.R
+++ b/R/mod_project.R
@@ -24,7 +24,7 @@ mod_project_ui <- function(id) {
 #' project Server Functions
 #'
 #' @noRd
-mod_project_server <- function(id, project) {
+mod_project_server <- function(id, project, user) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
     

--- a/R/mod_reporting.R
+++ b/R/mod_reporting.R
@@ -31,7 +31,7 @@ mod_reporting_ui <- function(id){
 #' reporting Server Functions
 #'
 #' @noRd
-mod_reporting_server <- function(id, project){
+mod_reporting_server <- function(id, project, user){
   moduleServer(id, function(input, output, session){
     ns <- session$ns
 


### PR DESCRIPTION
- prepwork for working with user data
- all modules that are currently in use and that may need it, can access user data via `user() `reactive value
- the value has a form of 1 row `data.frame`, with user_id, user supplied values, date created, `project_id`, and permission variables
- e.g., to get user_id, get `user()$user_id` inside a module

```
# A tibble: 1 x 11
  user_id user_name  user_mail created_at  project_id can_code
    <int> <chr>      <chr>     <chr>            <int>    <int>
1       1 Name Lastname mail@example.com         2022-03-10…          1        1
# … with 5 more variables: can_modify_codes <int>,
#   can_delete_codes <int>, can_modify_documents <int>,
#   can_delete_documents <int>, can_manage <int>
```

