### PR TITLE
Patch+fix/code positions

### DIFF
--- a/R/mod_document_code.R
+++ b/R/mod_document_code.R
@@ -184,12 +184,11 @@ segments_observer <- reactiveVal(0)
                          startOff, 
                          endOff)
         
-        display_text <- load_doc_to_display(project()$active_project, 
+        text(load_doc_to_display(project()$active_project, 
                                             project()$project_db, 
                                             input$doc_selector,
                                             code_df$active_codebook,
-                                            ns=NS(id))
-        text(display_text)
+                                            ns=NS(id)))
         segments_observer(segments_observer()+1)
         
         }

--- a/R/mod_document_code_utils_document_code.R
+++ b/R/mod_document_code_utils_document_code.R
@@ -100,8 +100,8 @@ check_overlap <- function(coded_segments, startOff, endOff){
 
     overlapping_segments <- coded_segments %>%
         dplyr::rowwise() %>%
-        dplyr::mutate(overlapping = dplyr::between(startOff, segment_start, segment_end) |
-                          dplyr::between(endOff, segment_start, segment_end)) %>%
+        dplyr::mutate(overlapping = dplyr::between(segment_start, startOff, endOff) |
+                          dplyr::between(segment_end, startOff, endOff)) %>%
         dplyr::filter(overlapping)
 
     if(!nrow(overlapping_segments)){
@@ -233,9 +233,9 @@ res <- dplyr::tibble(
   segment_end = NULL
 )
 
-for (i in seq_along(vals)) {
+for (i in seq_along(vals)) { 
   overlap_df <- raw_segments %>%
-    dplyr::filter(vals[i] > segment_start & vals[i] <= segment_end)
+    dplyr::filter(vals[i] >= segment_start && vals[i] <= segment_end)
   if (names(vals[i]) == "segment_start") {
     res <- dplyr::bind_rows(
       res,
@@ -258,6 +258,7 @@ for (i in seq_along(vals)) {
 }
 
 if (nrow(res)) {
+  
 prefinal <- res %>%
   dplyr::mutate(
     code_id = dplyr::lead(code_id),
@@ -266,7 +267,6 @@ prefinal <- res %>%
   dplyr::filter(code_id != "",
                 !is.na(code_id)) %>% 
     dplyr::mutate(segment_id = 0:(dplyr::n()-1))  } else {res}
-    
 
 }
 
@@ -286,6 +286,7 @@ load_doc_to_display <- function(active_project,
                                        doc_selector) %>% 
         calculate_code_overlap()
     
+
     code_names <- codebook %>%
         dplyr::select(code_id, code_name, code_color) %>%
         dplyr::mutate(code_id = as.character(code_id))
@@ -311,6 +312,7 @@ load_doc_to_display <- function(active_project,
         )
         
         content_df <-coded_segments %>% 
+            dplyr::filter(segment_start <= segment_end) %>% # patch for failing calculate_code_overlap() function in case of identical code positions
             dplyr::mutate(code_id = as.character(code_id)) %>% 
             tidyr::pivot_longer(cols = c(segment_start, segment_end),
                                 values_to = "position_start", 

--- a/R/mod_document_code_utils_document_code.R
+++ b/R/mod_document_code_utils_document_code.R
@@ -235,7 +235,7 @@ res <- dplyr::tibble(
 
 for (i in seq_along(vals)) { 
   overlap_df <- raw_segments %>%
-    dplyr::filter(vals[i] >= segment_start && vals[i] <= segment_end)
+    dplyr::filter(vals[i] > segment_start & vals[i] <= segment_end)
   if (names(vals[i]) == "segment_start") {
     res <- dplyr::bind_rows(
       res,

--- a/tests/testthat/test-check_overlap.R
+++ b/tests/testthat/test-check_overlap.R
@@ -1,0 +1,14 @@
+coded_segments_test <- data.frame(
+    project_id = 1, 
+    doc_id = 1, 
+    code_id = 1, 
+    segment_id = 1, 
+    segment_start = 1, 
+    segment_end = 4, 
+    segment_text = "ahoj"
+)
+
+test_that("code_overlap works", {
+    expect_true(nrow(check_overlap(coded_segments_test, 6, 10)) == 0)
+    expect_true(nrow(check_overlap(coded_segments_test, 2, 10)) == 1)
+})


### PR DESCRIPTION
- Patches #71 
  - the function `calculate_code_overlap()` still fails to return correct results in case of identical code positions, but there is an easy fix for it downstream
- Fixes the issue of the same code extension
- displayed text variable is now updated directly instead of an intermediary variable