### PR TITLE
Display warning if pandoc is not available

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -22,9 +22,9 @@ jobs:
       matrix:
         config:
           - {os: windows-latest, r: 'release'}
-          # - {os: macOS-latest, r: 'release'}
+          - {os: macOS-latest, r: 'release'}
           - {os: ubuntu-20.04, r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
-          - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
+          # - {os: ubuntu-20.04, r: 'devel', rspm: "https://packagemanager.rstudio.com/cran/__linux__/focal/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/R/mod_download_html.R
+++ b/R/mod_download_html.R
@@ -14,7 +14,7 @@ mod_download_html_ui <- function(id){
           downloadButton(ns("report"), "HTML")
       }else{
           list(downloadButton(ns("report"), "HTML", class = "disabled"), 
-               HTML("Install <a href='https://bookdown.org/yihui/rmarkdown-cookbook/install-pandoc.html'>pandoc</a> to enable HTML export"))
+               htmltools::HTML("Install <a href='https://bookdown.org/yihui/rmarkdown-cookbook/install-pandoc.html'>pandoc</a> to enable HTML export"))
       }
   )
 }

--- a/R/mod_download_html.R
+++ b/R/mod_download_html.R
@@ -10,7 +10,12 @@
 mod_download_html_ui <- function(id){
   ns <- NS(id)
   tagList(
-      downloadButton(ns("report"), "HTML")
+      if(rmarkdown::pandoc_available()){
+          downloadButton(ns("report"), "HTML")
+      }else{
+          list(downloadButton(ns("report"), "HTML", class = "disabled"), 
+               HTML("Install <a href='https://bookdown.org/yihui/rmarkdown-cookbook/install-pandoc.html'>pandoc</a> to enable HTML export"))
+      }
   )
 }
     


### PR DESCRIPTION
closes #92 
- if `pandoc` is not available, the button is disabled and text stating that the user needs to install `pandoc` is displayed
- if `pandoc` is available, the button is enabled