### PR TITLE
Schema update

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: requal
 Title: Shiny Application for Computer-Assisted Qualitative Data Analysis
-Version: 0.8.1
+Version: 0.8.2
 Authors@R:
     c(
      person(given = "Radim",

--- a/R/db_startup.R
+++ b/R/db_startup.R
@@ -8,6 +8,8 @@ CREATE TABLE if not exists attributes (
 ,   attribute_name TEXT
 ,   attribute_object TEXT
 ,   attribute_type TEXT
+,   user_id INTEGER
+,   FOREIGN KEY(user_id) REFERENCES users(user_id)
 );
 ",
 

--- a/R/db_startup.R
+++ b/R/db_startup.R
@@ -1,74 +1,19 @@
-CREATE_PROJECT_SQL <- "
-CREATE TABLE projects (
-     project_id INTEGER PRIMARY KEY AUTOINCREMENT
-,    project_name TEXT
-,    project_description TEXT
-,    created_at TEXT DEFAULT CURRENT_TIMESTAMP
-);
-"
-CREATE_PROJECT_SQL_POSTGRES <- "
-CREATE TABLE projects (
-    project_id SERIAL PRIMARY KEY
-    ,    project_name TEXT
-    ,    project_description TEXT
-    ,    created_at TEXT DEFAULT CURRENT_TIMESTAMP
-);
-"
-CREATE_REQUAL_INFO_SQL <- "
-CREATE TABLE if not exists requal_version (
-    project_id INTEGER
-,   version TEXT
-,   FOREIGN KEY(project_id) REFERENCES projects(project_id)
-);
-"
-# TODO: user_attributes
-CREATE_USERS_SQL <- "
-CREATE TABLE if not exists users (
-    user_id INTEGER PRIMARY KEY
-,   user_login TEXT UNIQUE
-,   user_name TEXT
-,   user_mail TEXT
-,   created_at TEXT DEFAULT CURRENT_TIMESTAMP
-);
-"
 
-CREATE_ATTRIBUTES_SQL <- "
+db_call <- c(
+
+"attributes" =
+"
 CREATE TABLE if not exists attributes (
     attribute_id INTEGER PRIMARY KEY AUTOINCREMENT
 ,   attribute_name TEXT
 ,   attribute_object TEXT
 ,   attribute_type TEXT
 );
-"
-CREATE_ATTRIBUTES_SQL_POSTGRES <- "
-CREATE TABLE if not exists attributes (
-    attribute_id SERIAL PRIMARY KEY
-,   attribute_name TEXT
-,   attribute_object TEXT
-,   attribute_type TEXT
-);
-"
+",
 
-CREATE_ATTRIBUTE_VALUES_SQL <- "
-CREATE TABLE if not exists attribute_values (
-    attribute_value_id INTEGER PRIMARY KEY AUTOINCREMENT
-,   attribute_id INTEGER
-,   value TEXT
-,   FOREIGN KEY(attribute_id) REFERENCES attributes(attribute_id)
-);
+"attributes_users_map" =
 "
-
-CREATE_ATTRIBUTE_VALUES_SQL_POSTGRES <- "
-CREATE TABLE if not exists attribute_values (
-    attribute_value_id SERIAL PRIMARY KEY 
-,   attribute_id INTEGER
-,   value TEXT
-,   FOREIGN KEY(attribute_id) REFERENCES attributes(attribute_id)
-);
-"
-
-CREATE_ATTRIBUTE_USER_MAP_SQL <- "
-CREATE TABLE if not exists user_attribute_map (
+CREATE TABLE if not exists attributes_users_map (
     user_id INTEGER
 ,   attribute_id INTEGER
 ,   attribute_value_id INTEGER 
@@ -76,37 +21,79 @@ CREATE TABLE if not exists user_attribute_map (
 ,   FOREIGN KEY(attribute_id) REFERENCES attributes(attribute_id)
 ,   FOREIGN KEY(attribute_value_id) REFERENCES attribute_values(attribute_value_id)
 );
+",
+
+"attribute_values" =
 "
+CREATE TABLE if not exists attribute_values (
+    attribute_value_id INTEGER PRIMARY KEY AUTOINCREMENT
+,   attribute_id INTEGER
+,   value TEXT
+,   FOREIGN KEY(attribute_id) REFERENCES attributes(attribute_id)
+);
+",
 
-
-CREATE_USER_PERMISSIONS_SQL <- "
-CREATE TABLE if not exists user_permissions (
-    user_id INTEGER
-,   project_id INTEGER
-,   can_code INTEGER
-,   can_modify_codes INTEGER
-,   can_delete_codes INTEGER
-,   can_modify_documents INTEGER
-,   can_delete_documents INTEGER
-,   can_manage INTEGER
-,   FOREIGN KEY(user_id) REFERENCES users(user_id)
+"cases" =
+"
+CREATE TABLE if not exists cases (
+    project_id INTEGER
+,   case_id INTEGER PRIMARY KEY AUTOINCREMENT
+,   case_name TEXT
+,   case_description TEXT
 ,   FOREIGN KEY(project_id) REFERENCES projects(project_id)
 );
-"
+",
 
-CREATE_LOG_SQL <- "
-CREATE TABLE if not exists logs
-(   user_id INTEGER
-,   project_id INTEGER
-,   action TEXT
-,   payload JSON
-,   created_at TEXT DEFAULT CURRENT_TIMESTAMP
+
+"cases_documents_map" =
+"
+CREATE TABLE if not exists cases_documents_map (
+    project_id INTEGER
+,   case_id INTEGER
+,   doc_id INTEGER
 ,   FOREIGN KEY(project_id) REFERENCES projects(project_id)
-,   FOREIGN KEY(user_id) REFERENCES users(user_id)
+,   FOREIGN KEY(case_id) REFERENCES cases(case_id)
+,   FOREIGN KEY(doc_id) REFERENCES documents(doc_id)
 );
-"
+",
 
-CREATE_DOCUMENTS_SQL <- "
+"categories" =
+"
+CREATE TABLE if not exists categories (
+    project_id INTEGER
+,   category_id INTEGER PRIMARY KEY AUTOINCREMENT
+,   category_name TEXT
+,   category_description TEXT
+,   FOREIGN KEY(project_id) REFERENCES projects(project_id)
+);
+",
+
+"categories_codes_map" =
+"
+CREATE TABLE if not exists categories_codes_map (
+    project_id INTEGER
+,   category_id INTEGER
+,   code_id INTEGER
+,   FOREIGN KEY(project_id) REFERENCES projects(project_id)
+,   FOREIGN KEY(category_id) REFERENCES categories(category_id)
+,   FOREIGN KEY(code_id) REFERENCES codes(code_id)
+);
+",
+
+"codes" =
+"
+CREATE TABLE if not exists codes (
+    project_id INTEGER
+,   code_id INTEGER PRIMARY KEY AUTOINCREMENT
+,   code_name TEXT UNIQUE
+,   code_description TEXT
+,   code_color TEXT
+,   FOREIGN KEY(project_id) REFERENCES projects(project_id)
+);
+",
+
+"documents" =
+"
 CREATE TABLE if not exists documents (
     doc_id INTEGER PRIMARY KEY AUTOINCREMENT
 ,   project_id INTEGER
@@ -116,43 +103,84 @@ CREATE TABLE if not exists documents (
 ,   created_at TEXT DEFAULT CURRENT_TIMESTAMP
 ,   FOREIGN KEY(project_id) REFERENCES projects(project_id)
 );
-"
+",
 
-CREATE_DOCUMENTS_SQL_POSTGRES <- "
-CREATE TABLE if not exists documents (
-    doc_id SERIAL PRIMARY KEY
+"logs" =
+"
+CREATE TABLE if not exists logs
+(   user_id INTEGER
 ,   project_id INTEGER
-,   doc_name TEXT
-,   doc_description TEXT
-,   doc_text TEXT
+,   action TEXT
+,   payload JSON
 ,   created_at TEXT DEFAULT CURRENT_TIMESTAMP
 ,   FOREIGN KEY(project_id) REFERENCES projects(project_id)
+,   FOREIGN KEY(user_id) REFERENCES users(user_id)
 );
-"
+",
 
-CREATE_CODES_SQL <- "
-CREATE TABLE if not exists codes (
+"memos" =
+"
+CREATE TABLE if not exists memos (
     project_id INTEGER
-,   code_id INTEGER PRIMARY KEY AUTOINCREMENT
-,   code_name TEXT UNIQUE
-,   code_description TEXT
-,   code_color TEXT
+,   memo_id INTEGER PRIMARY KEY
+,   text TEXT
 ,   FOREIGN KEY(project_id) REFERENCES projects(project_id)
 );
-"
+",
 
-CREATE_CODES_SQL_POSTGRES <- "
-CREATE TABLE if not exists codes (
+"memos_codes_map" =
+"
+CREATE TABLE if not exists memos_codes_map (
+    memo_id INTEGER
+    ,   code_id INTEGER
+    ,   FOREIGN KEY(code_id) REFERENCES codes(code_id)
+    ,   FOREIGN KEY(memo_id) REFERENCES memos(memo_id)
+);
+",
+
+"memos_documents_map" =
+"
+CREATE TABLE if not exists memos_documents_map (
+    memo_id INTEGER
+    ,   doc_id INTEGER
+    ,   memo_start INTEGER
+    ,   memo_end INTEGER
+    ,   FOREIGN KEY(doc_id) REFERENCES documents(doc_id)
+    ,   FOREIGN KEY(memo_id) REFERENCES memos(memo_id)
+);
+",
+
+"memos_segments_map" =
+"
+CREATE TABLE if not exists memos_segments_map (
+    memo_id INTEGER
+    ,   segment_id INTEGER
+    ,   FOREIGN KEY(segment_id) REFERENCES segments(segment_id)
+    ,   FOREIGN KEY(memo_id) REFERENCES memos(memo_id)
+);
+",
+
+"projects" =
+"
+CREATE TABLE projects (
+     project_id INTEGER PRIMARY KEY AUTOINCREMENT
+,    project_name TEXT
+,    project_description TEXT
+,    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+",
+
+"requal_version" = 
+"
+CREATE TABLE if not exists requal_version (
     project_id INTEGER
-,   code_id SERIAL PRIMARY KEY 
-,   code_name TEXT UNIQUE
-,   code_description TEXT
-,   code_color TEXT
+,   version TEXT
 ,   FOREIGN KEY(project_id) REFERENCES projects(project_id)
 );
-"
+",
 
-CREATE_SEGMENTS_SQL <- "
+"segments" =
+"
 CREATE TABLE if not exists segments (
     project_id INTEGER
 ,   user_id INTEGER
@@ -167,143 +195,74 @@ CREATE TABLE if not exists segments (
 ,   FOREIGN KEY(code_id) REFERENCES codes(code_id)
 ,   FOREIGN KEY(user_id) REFERENCES users(user_id)
 );
-"
+",
 
-CREATE_SEGMENTS_SQL_POSTGRES <- "
-CREATE TABLE if not exists segments (
-    project_id INTEGER
-,   user_id INTEGER
-,   doc_id INTEGER
-,   code_id INTEGER
-,   segment_id SERIAL PRIMARY KEY
-,   segment_start INTEGER
-,   segment_end INTEGER
-,   segment_text TEXT
-,   FOREIGN KEY(project_id) REFERENCES projects(project_id)
-,   FOREIGN KEY(doc_id) REFERENCES documents(doc_id)
-,   FOREIGN KEY(code_id) REFERENCES codes(code_id)
+"users" =
+"
+CREATE TABLE if not exists users (
+    user_id INTEGER PRIMARY KEY
+,   user_login TEXT UNIQUE
+,   user_name TEXT
+,   user_mail TEXT
+,   created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+",
+
+"user_permissions" =
+"
+CREATE TABLE if not exists user_permissions (
+    user_id INTEGER
+,   project_id INTEGER
+,   can_code INTEGER
+,   can_modify_codes INTEGER
+,   can_delete_codes INTEGER
+,   can_modify_documents INTEGER
+,   can_delete_documents INTEGER
+,   can_manage INTEGER
 ,   FOREIGN KEY(user_id) REFERENCES users(user_id)
-);
-"
-
-CREATE_CATEGORIES_SQL <- "
-CREATE TABLE if not exists categories (
-    project_id INTEGER
-,   category_id INTEGER PRIMARY KEY AUTOINCREMENT
-,   category_name TEXT
-,   category_description TEXT
 ,   FOREIGN KEY(project_id) REFERENCES projects(project_id)
 );
 "
+)
 
-CREATE_CATEGORIES_SQL_POSTGRES <- "
-CREATE TABLE if not exists categories (
-    project_id INTEGER
-,   category_id SERIAL PRIMARY KEY
-,   category_name TEXT
-,   category_description TEXT
-,   FOREIGN KEY(project_id) REFERENCES projects(project_id)
-);
-"
+db_call_df_unordered <- tibble::tibble(
+  table = names(db_call),
+  sql = db_call
+)
 
-CREATE_CATEGORY_CODE_MAP_SQL <- "
-CREATE TABLE if not exists categories_codes_map (
-    project_id INTEGER
-,   category_id INTEGER
-,   code_id INTEGER
-,   FOREIGN KEY(project_id) REFERENCES projects(project_id)
-,   FOREIGN KEY(category_id) REFERENCES categories(category_id)
-,   FOREIGN KEY(code_id) REFERENCES codes(code_id)
-);
-"
+db_call_df_ordered <- tibble::tibble(
+table = c(
+"projects", 
+"requal_version", 
+"users", 
+"user_permissions", 
+"logs",
+"documents", 
+"codes", 
+"categories", 
+"categories_codes_map", 
+"cases", 
+"cases_documents_map", 
+"segments", 
+"memos", 
+"attributes", 
+"attribute_values"
+))
 
-CREATE_CASES_SQL <- "
-CREATE TABLE if not exists cases (
-    project_id INTEGER
-,   case_id INTEGER PRIMARY KEY AUTOINCREMENT
-,   case_name TEXT
-,   case_description TEXT
-,   FOREIGN KEY(project_id) REFERENCES projects(project_id)
-);
-"
+db_call_df <- dplyr::full_join(
+  db_call_df_ordered,
+  db_call_df_unordered,
+  by = "table"
+)
 
-CREATE_CASES_SQL_POSTGRES <- "
-CREATE TABLE if not exists cases (
-    project_id INTEGER
-,   case_id SERIAL PRIMARY KEY
-,   case_name TEXT
-,   case_description TEXT
-,   FOREIGN KEY(project_id) REFERENCES projects(project_id)
-);
-"
-
-CREATE_CASE_DOC_MAP_SQL <- "
-CREATE TABLE if not exists cases_documents_map (
-    project_id INTEGER
-,   case_id INTEGER
-,   doc_id INTEGER
-,   FOREIGN KEY(project_id) REFERENCES projects(project_id)
-,   FOREIGN KEY(case_id) REFERENCES cases(case_id)
-,   FOREIGN KEY(doc_id) REFERENCES documents(doc_id)
-);
-"
-
-# TODO: hierarchy between codes, cases, categories (code_code_map, case_case_map, category_category_map)
-
-# memos
-CREATE_MEMO_SQL <- "
-CREATE TABLE if not exists memos (
-    project_id INTEGER
-,   memo_id INTEGER PRIMARY KEY
-,   text TEXT
-,   FOREIGN KEY(project_id) REFERENCES projects(project_id)
-);
-"
-
-CREATE_MEMO_SQL_POSTGRES <- "
-CREATE TABLE if not exists memos (
-    project_id INTEGER
-,   memo_id SERIAL PRIMARY KEY
-,   text TEXT
-,   FOREIGN KEY(project_id) REFERENCES projects(project_id)
-);
-"
-
-
-CREATE_MEMO_DOCUMENT_MAP_SQL <- "
-CREATE TABLE if not exists memos_documents_map (
-    memo_id INTEGER
-    ,   doc_id INTEGER
-    ,   memo_start INTEGER
-    ,   memo_end INTEGER
-    ,   FOREIGN KEY(doc_id) REFERENCES documents(doc_id)
-    ,   FOREIGN KEY(memo_id) REFERENCES memos(memo_id)
-);
-"
-
-CREATE_MEMO_CODE_MAP_SQL <- "
-CREATE TABLE if not exists memos_codes_map (
-    memo_id INTEGER
-    ,   code_id INTEGER
-    ,   FOREIGN KEY(code_id) REFERENCES codes(code_id)
-    ,   FOREIGN KEY(memo_id) REFERENCES memos(memo_id)
-);
-"
-
-CREATE_MEMO_SEGMENT_MAP_SQL <- "
-CREATE TABLE if not exists memos_segments_map (
-    memo_id INTEGER
-    ,   segment_id INTEGER
-    ,   FOREIGN KEY(segment_id) REFERENCES segments(segment_id)
-    ,   FOREIGN KEY(memo_id) REFERENCES memos(memo_id)
-);
-"
 
 
 create_db_schema <- function(pool) {
   # TODO: Full DB structure
   db_postgres <- pool::dbGetInfo(pool)$pooledObjectClass != "SQLiteConnection"
   if (db_postgres) {
+
+
     DBI::dbExecute(pool, CREATE_PROJECT_SQL_POSTGRES)
     DBI::dbExecute(pool, CREATE_REQUAL_INFO_SQL)
     DBI::dbExecute(pool, CREATE_USERS_SQL)

--- a/R/db_startup.R
+++ b/R/db_startup.R
@@ -299,15 +299,13 @@ update_db_schema <- function(pool) {
         )
       purrr::walk(to_create_tables$psql, ~ DBI::dbExecute(pool, .x))
     } else {
-      existing_tables <- pool::dbListTables(pool)
-      existing_tables_no_sqlite <- existing_tables[!grepl("sqlite", existing_tables)]
-      missing_tables <- setdiff(db_call_df$table, existing_tables_no_sqlite)
+    
       to_create_tables <- db_call_df %>%
         dplyr::filter(table %in% missing_tables)
 
       purrr::walk(to_create_tables$sql, ~ DBI::dbExecute(pool, .x))
-      print("update schema")
     }
+    message("Updated reQual schema.")
   } else {
     NULL
   }

--- a/R/mod_launchpad_loader.R
+++ b/R/mod_launchpad_loader.R
@@ -66,6 +66,8 @@ mod_launchpad_loader_server <- function(id, glob, setup) {
             })
           })
 
+        update_db_schema(glob$pool)
+
 
           updateSelectInput(session,
             "project_selector_load",
@@ -130,6 +132,8 @@ mod_launchpad_loader_server <- function(id, glob, setup) {
             pool::poolClose(glob$pool)
           })
         })
+
+        update_db_schema(glob$pool)
       }
       
       observeEvent(glob$pool, {

--- a/R/mod_user_utils_user.R
+++ b/R/mod_user_utils_user.R
@@ -51,7 +51,7 @@ update_user_attributes <- function(pool, project_id, user_id, user_attributes_df
     
     purrr::walk(seq_len(nrow(user_attributes_df)), function(x) {
         # Check if attribute has value
-        existing_attr <- dplyr::tbl(pool, "user_attribute_map") %>% 
+        existing_attr <- dplyr::tbl(pool, "attributes_users_map") %>% 
             dplyr::filter(.data$user_id == !!user_id & 
                               .data$attribute_id == !!user_attributes_df$attribute_id[x]) %>% 
             dplyr::collect()
@@ -61,7 +61,7 @@ update_user_attributes <- function(pool, project_id, user_id, user_attributes_df
             attr_value <- user_attributes_df$attribute_value_id[x]
             
             if(existing_attr$attribute_value_id != attr_value){
-                update_attributes_sql <- glue::glue_sql("UPDATE user_attribute_map
+                update_attributes_sql <- glue::glue_sql("UPDATE attributes_users_map
                  SET attribute_value_id = {attr_value}
                  WHERE user_id = {user_id} AND attribute_id = {attr_id}", .con = pool)
                 
@@ -76,7 +76,7 @@ update_user_attributes <- function(pool, project_id, user_id, user_attributes_df
         }else{
             values_df <- user_attributes_df[x,] %>% 
                 dplyr::select(user_id, attribute_id, attribute_value_id)
-            DBI::dbWriteTable(pool, "user_attribute_map", 
+            DBI::dbWriteTable(pool, "attributes_users_map", 
                               values_df, append = TRUE, row.names = FALSE)
             log_change_user_attribute(pool, local(project_id), 
                                       values_df, 

--- a/R/mod_user_utils_user.R
+++ b/R/mod_user_utils_user.R
@@ -86,7 +86,7 @@ update_user_attributes <- function(pool, project_id, user_id, user_attributes_df
 }
 
 read_user_attributes_by_id <- function(pool, user_id){
-    dplyr::tbl(pool, "user_attribute_map") %>% 
+    dplyr::tbl(pool, "attributes_users_map") %>% 
         dplyr::filter(.data$user_id == !!user_id) %>% 
         dplyr::left_join(., dplyr::tbl(pool, "attributes"), by = "attribute_id") %>%
         dplyr::left_join(., dplyr::tbl(pool, "attribute_values"), 

--- a/dev/run_dev.R
+++ b/dev/run_dev.R
@@ -10,7 +10,7 @@ golem::document_and_reload()
 
 # Run the application
 (run_app(
-  mode = "server",
+  mode = "local",
   dbname = "requal",
   dbusername = "requal_admin",
   dbpassword = "test",


### PR DESCRIPTION
Facilitate requal updates:

- On project load, perform a check of requal version schema to the existing project schema.
- If some tables are missing, create them. 
- SQL queries and `create_db_schema` optimized to support the above features

Closes https://github.com/RE-QDA/docs/issues/41.

Possible future improvements:

Create missing columns.

Requal version columns can be extracted by regex, e.g.:

```
tbl_cols_matches <- stringr::str_remove_all(db_call[1], "[\n\r\\s]") %>%
stringr::str_match_all("[\\(\\,]([a-z_]+)")
tbl_cols <- unique(tbl_cols_matches[[1]][,2])
```