### PR TITLE
Fix warning on Windows

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: requal
 Title: Shiny Application for Computer-Assisted Qualitative Data Analysis
-Version: 0.8.2.9001
+Version: 0.8.2.9002
 Authors@R:
     c(
      person(given = "Radim",

--- a/R/mod_download_html.R
+++ b/R/mod_download_html.R
@@ -35,10 +35,12 @@ mod_download_html_server <- function(id, glob){
             # case we don't have write permissions to the current working dir (which
             # can happen when deployed).
             
-            tempHTML <- normalizePath(file.path(tempdir(), "report_include.html"), winslash = "/")
+            tempHTML <- normalizePath(file.path(tempdir(), "report_include.html"), 
+                                      winslash = "/", mustWork = FALSE)
             cat(as.character(tagList(glob$segments_taglist)), file = tempHTML)
 
-            tempReport <- normalizePath(file.path(tempdir(), "report.Rmd"), winslash = "/")
+            tempReport <- normalizePath(file.path(tempdir(), "report.Rmd"), 
+                                        winslash = "/", mustWork = FALSE)
             fileConn<-file(tempReport)
             writeLines(c("---",
                          "title: 'reQual report'",


### PR DESCRIPTION
removes warning on Win 7 when exporting analysis as HTML file