### PR TITLE
hotfix owner permissions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: requal
 Title: Shiny Application for Computer-Assisted Qualitative Data Analysis
-Version: 1.1.1.9001
+Version: 1.1.1.9002
 Authors@R:
     c(
      person(given = "Radim",

--- a/R/mod_user_manager.R
+++ b/R/mod_user_manager.R
@@ -104,6 +104,9 @@ mod_user_manager_server <- function(id, glob) {
         x  <- 1 # apply new permissions
       }))
 
+      # Enforce that project owner can always modify permission
+      modified_permissions_df$permissions_modify[modified_permissions_df$project_owner == 1] <- 1
+      
       modify_permissions_record(
         pool = glob$pool,
         project_id = glob$active_project,


### PR DESCRIPTION
Project owner always retains permission to modify permissions.
Fixes #131 