### PR TITLE
Fix css for custom logout btn

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: requal
 Title: Shiny Application for Computer-Assisted Qualitative Data Analysis
-Version: 1.1.2
+Version: 1.1.2.9001
 Authors@R:
     c(
      person(given = "Radim",

--- a/inst/app/www/custom.css
+++ b/inst/app/www/custom.css
@@ -138,7 +138,7 @@ width: 100% !important;
 .mfb-component--bl {
   display: none;
 }
-#\.shinymanager_logout {
+#\.shinymanager_logout.mfb-component__button--child {
   display: none;
 }
 #\.shinymanager_admin {


### PR DESCRIPTION
Due to shinymanager handling of logout buttons, we have two elements with the same id, so I had to add a class specification to keep the default hidden but display the custom