### PR TITLE
Regenerate - reinventing our html pipeline

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: requal
 Title: Shiny Application for Computer-Assisted Qualitative Data Analysis
-Version: 1.1.3.9001
+Version: 1.2.1.9001
 Authors@R:
     c(
      person(given = "Radim",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: requal
 Title: Shiny Application for Computer-Assisted Qualitative Data Analysis
-Version: 1.2.1.9001
+Version: 1.2.1.9002
 Authors@R:
     c(
      person(given = "Radim",

--- a/R/mod_document_code.R
+++ b/R/mod_document_code.R
@@ -214,7 +214,7 @@ mod_document_code_server <- function(id, glob) {
   })
 
     # Render text and codes ----
-    output$focal_text <- renderText({
+    output$focal_text <- renderUI({
       req(isTruthy(loc$text))
       loc$text
     })

--- a/R/mod_document_code_utils_document_code.R
+++ b/R/mod_document_code_utils_document_code.R
@@ -283,6 +283,7 @@ load_doc_to_display <- function(pool,
                                 codebook,
                                 highlight,
                                 ns){
+    end <- highlight_id <- par_id <- NULL
     raw_text <- load_doc_db(pool, active_project, doc_selector)
     total_chars <- nchar(raw_text)
     paragraph_indices <- tibble::as_tibble(stringr::str_locate_all(raw_text, "\n|\r")[[1]])

--- a/R/mod_document_code_utils_document_code.R
+++ b/R/mod_document_code_utils_document_code.R
@@ -349,7 +349,7 @@ load_doc_to_display <- function(pool,
      
     } else {
   
-    spans <- paragraphs |> 
+    spans <- paragraphs %>%  
         dplyr::mutate(text = purrr::pmap(
             list(segment_start, segment_end, raw_text = raw_text),
             make_span

--- a/inst/app/www/custom.css
+++ b/inst/app/www/custom.css
@@ -88,14 +88,10 @@ p.docpar::before {
   width: 0px;
 }
 
-b.segment {
-  font-weight: normal;
+span.segment {
   text-decoration-thickness: 5px !important; 
   text-underline-offset: 3px !important;
 }
-
-
-
 
 .category-rank-list {
 -webkit-border-radius: 1px;
@@ -216,7 +212,7 @@ display: flex;
   text-decoration-color: red;
 }
 
-.docpar b::selection {
+.docpar span::selection {
   background: rgba(255, 223, 0, 0.5); /* A more contrasting yellow with some transparency */
   color: black;
   text-decoration: underline; /* Fallback for browsers that don't support advanced styles */

--- a/tests/testthat/test-document-code-utils.R
+++ b/tests/testthat/test-document-code-utils.R
@@ -2,6 +2,7 @@ coded_segments_df <- dplyr::tibble(
     project_id = 1,
     code_id = 1, 
     doc_id = 1,
+    segment_id = c(1, 2), 
     segment_start = c(10, 30), 
     segment_end = c(20, 40)
 )
@@ -10,10 +11,12 @@ coded_segments_overlap <- dplyr::tibble(
     project_id = 1, 
     code_id = c(1, 2), 
     doc_id = 1, 
+    segment_id = c(1, 2), 
     segment_start = c(10, 20), 
     segment_end = c(30, 40)
 )
 
+paragraphs <- NULL
 test_that("Test overlap checking returns correct nrows", {
     expect_true(nrow(check_overlap(coded_segments_df, 0, 8)) == 0)
     expect_true(nrow(check_overlap(coded_segments_df, 20, 25)) == 1)
@@ -46,9 +49,11 @@ test_that("Test that calculating new segment range works", {
 })
 
 test_that("Test that calculating code overlap works", {
-    expect_true(nrow(calculate_code_overlap(coded_segments_df)) == 2)
-    expect_true(nrow(calculate_code_overlap(coded_segments_overlap)) == 3)
-    expect_true(all(calculate_code_overlap(coded_segments_overlap) %>% 
-                        dplyr::pull(code_id) %in% c("1", "1+2", "2")))
+    expect_true(nrow(calculate_code_overlap(coded_segments_df, paragraphs)) == 2)
+    expect_true(nrow(calculate_code_overlap(coded_segments_overlap, paragraphs)) == 3)
+    expect_true(all(calculate_code_overlap(coded_segments_overlap, paragraphs) %>% 
+                        dplyr::pull(code_id) %in% c("1", "1-2", "2")))
     
 })
+
+library(testthat)


### PR DESCRIPTION
Fundamental backend changes:
- new streamlined, efficient, and accurate algorithm for overlap calculation
- displayed text constructor refactored to output `shiny.taglist` class

Related to #34 
Fixes a bug where segments in the length of 1 character were not displayed in annotation screen