### PR TITLE
Codebook csv import

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: requal
 Title: Shiny Application for Computer-Assisted Qualitative Data Analysis
-Version: 1.1.3.9001
+Version: 1.1.4.9001
 Authors@R:
     c(
      person(given = "Radim",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# requal DEV version
+
+- Codebook import
+  - code names, descriptions, and colors can be imported via a CSV file
+
 # requal 1.1.3 Rieppeleon
 
 __Release notes:__  

--- a/R/mod_codebook.R
+++ b/R/mod_codebook.R
@@ -14,28 +14,38 @@ mod_codebook_ui <- function(id) {
     tabsetPanel(
       type = "tabs",
       id = ns("codebook_tabset"),
-      tabPanel("Codes",
+      tabPanel(
+        "Codes",
         id = ns("codebook_tabset"),
         value = "codebook_tabset",
-    fluidRow(
-      class = "module_tools",
-      mod_rql_button_ui(ns("code_create_ui"),
-        label = "Create code",
-        icon = "plus"
-      ),
-      mod_rql_button_ui(ns("code_edit_ui"),
-        label = "Edit codes",
-        icon = "edit"
-      ), 
-      mod_rql_button_ui(ns("code_merge_ui"),
-        label = "Merge codes",
-        icon = "compress"
-      ),     
-      mod_rql_button_ui(ns("code_delete_ui"),
-        label = "Delete code",
-        icon = "minus"
-      ),
-    ),
+        fluidRow(
+          class = "module_tools",
+          mod_rql_button_ui(
+            ns("code_create_ui"),
+            label = "Create code",
+            icon = "plus"
+          ),
+          mod_rql_button_ui(
+            ns("code_edit_ui"),
+            label = "Edit codes",
+            icon = "edit"
+          ),
+          mod_rql_button_ui(
+            ns("code_merge_ui"),
+            label = "Merge codes",
+            icon = "compress"
+          ),
+          mod_rql_button_ui(
+            ns("code_delete_ui"),
+            label = "Delete code",
+            icon = "minus"
+          ),
+          mod_rql_button_ui(
+            ns("code_import_ui"),
+            label = "Import codebook",
+            icon = "upload"
+          )
+        ),
         fluidRow(
           class = "module_content",
           column(
@@ -43,16 +53,18 @@ mod_codebook_ui <- function(id) {
             br(),
             uiOutput(
               ns("codes_ui")
-            ) %>% tagAppendAttributes(class = "scrollable90")
+            ) %>%
+              tagAppendAttributes(class = "scrollable90")
           )
         )
       ),
-      tabPanel("Categories",
+      tabPanel(
+        "Categories",
         id = ns("categories"),
         value = "categories",
-        mod_categories_ui("categories_ui_1") 
+        mod_categories_ui("categories_ui_1")
       )
-    ), 
+    ),
     downloadButton(ns("export_codebook"), label = "CSV")
   )
 }
@@ -65,73 +77,101 @@ mod_codebook_server <- function(id, glob) {
     ns <- session$ns
     loc <- reactiveValues()
 
-   # initialize codebook upon load
-   observeEvent(c(
-      glob$active_project,
-      input$code_add,
-      input$code_edit_btn,
-      input$code_merge,
-      input$code_del_btn,
-      glob$codebook_observer
-    ), {
-    #---Create code UI --------------
-    mod_rql_button_server(
-      id = "code_create_ui",
-      custom_title = "Create code",
-      custom_tagList = create_code_UI(ns),
-      glob,
-      permission = "codebook_modify"
-    )
-    #---Merge code UI --------------
-    mod_rql_button_server(
-      id = "code_merge_ui",
-      custom_title = "Merge codes",
-      custom_tagList = merge_code_UI(ns, glob$pool, glob$active_project, glob$user),
-      glob,
-      permission = "codebook_modify"
-    )
-    #---Edit code UI --------------
-    mod_rql_button_server(
-      id = "code_edit_ui",
-      custom_title = "Edit code",
-      custom_tagList = edit_code_UI(ns, glob$pool, glob$active_project, glob$user),
-      glob,
-      permission = "codebook_modify"
-    )
-    #---Delete code UI --------------
-    mod_rql_button_server(
-      id = "code_delete_ui",
-      custom_title = "Delete code",
-      custom_tagList = delete_code_UI(ns, glob$pool, glob$active_project, glob$user),
-      glob,
-      permission = "codebook_modify"
-    )
-    glob$codebook <- list_db_codes(
-            glob$pool,
-            glob$active_project, 
-            glob$user
+    # initialize codebook upon load
+    observeEvent(
+      c(
+        glob$active_project,
+        input$code_add,
+        input$code_edit_btn,
+        input$code_merge,
+        input$code_del_btn,
+        glob$codebook_observer
+      ),
+      {
+        #---Create code UI --------------
+        mod_rql_button_server(
+          id = "code_create_ui",
+          custom_title = "Create code",
+          custom_tagList = create_code_UI(ns),
+          glob,
+          permission = "codebook_modify"
         )
-  output$codes_ui <- renderUI({
-      render_codes(
-        active_project = glob$active_project,
-        pool = glob$pool, 
-        user = glob$user
-      )
-    })
-})
-  
+        #---Merge code UI --------------
+        mod_rql_button_server(
+          id = "code_merge_ui",
+          custom_title = "Merge codes",
+          custom_tagList = merge_code_UI(
+            ns,
+            glob$pool,
+            glob$active_project,
+            glob$user
+          ),
+          glob,
+          permission = "codebook_modify"
+        )
+        #---Edit code UI --------------
+        mod_rql_button_server(
+          id = "code_edit_ui",
+          custom_title = "Edit code",
+          custom_tagList = edit_code_UI(
+            ns,
+            glob$pool,
+            glob$active_project,
+            glob$user
+          ),
+          glob,
+          permission = "codebook_modify"
+        )
+        #---Delete code UI --------------
+        mod_rql_button_server(
+          id = "code_delete_ui",
+          custom_title = "Delete code",
+          custom_tagList = delete_code_UI(
+            ns,
+            glob$pool,
+            glob$active_project,
+            glob$user
+          ),
+          glob,
+          permission = "codebook_modify"
+        )
+
+        #---Import codebook UI --------------
+        mod_rql_button_server(
+          id = "code_import_ui",
+          custom_title = "Import codebook",
+          custom_tagList = mod_codebook_import_ui(ns("codebook_import_1")),
+          glob,
+          permission = "codebook_modify"
+        )
+
+        mod_codebook_import_ui("codebook_import_1")
+
+        glob$codebook <- list_db_codes(
+          glob$pool,
+          glob$active_project,
+          glob$user
+        )
+        output$codes_ui <- renderUI({
+          render_codes(
+            active_project = glob$active_project,
+            pool = glob$pool,
+            user = glob$user
+          )
+        })
+      }
+    )
+
     #---Create new code------------------------------------------------------
     observeEvent(input$code_add, {
-
       # check if code name is unique
       code_names <- list_db_codes(
         pool = glob$pool,
-        project_id = glob$active_project, 
+        project_id = glob$active_project,
         user = glob$user
       )$code_name
 
       if (!req(input$code_name) %in% code_names) {
-        
         codes_input_df <- data.frame(
           project_id = glob$active_project,
           code_name = input$code_name,
@@ -147,18 +187,18 @@ mod_codebook_server <- function(id, glob) {
               collapse = ", "
             ),
             ")"
-          ), 
+          ),
           user_id = glob$user$user_id
         )
 
         add_codes_record(
           pool = glob$pool,
           project_id = glob$active_project,
-          codes_df = codes_input_df, 
+          codes_df = codes_input_df,
           user_id = glob$user$user_id
         )
       } else {
-       warn_user("Code names must be unique and non-empty.")
+        warn_user("Code names must be unique and non-empty.")
       }
     })
 
@@ -169,23 +209,23 @@ mod_codebook_server <- function(id, glob) {
       updateTextInput(
         session = session,
         "edit_code_name",
-        value = glob$codebook %>% 
-            dplyr::filter(code_id == input$code_to_edit) %>%
-            dplyr::pull(code_name)
+        value = glob$codebook %>%
+          dplyr::filter(code_id == input$code_to_edit) %>%
+          dplyr::pull(code_name)
       )
       updateTextAreaInput(
         session = session,
         "edit_code_desc",
-        value = glob$codebook %>% 
-            dplyr::filter(code_id == input$code_to_edit) %>%
-            dplyr::pull(code_description)
+        value = glob$codebook %>%
+          dplyr::filter(code_id == input$code_to_edit) %>%
+          dplyr::pull(code_description)
       )
       colourpicker::updateColourInput(
         session = session,
         "edit_color_pick",
-        value = glob$codebook %>% 
-            dplyr::filter(code_id == input$code_to_edit) %>%
-            dplyr::pull(code_color)
+        value = glob$codebook %>%
+          dplyr::filter(code_id == input$code_to_edit) %>%
+          dplyr::pull(code_color)
       )
     })
     # Execute code edit
@@ -195,24 +235,25 @@ mod_codebook_server <- function(id, glob) {
       # check if code name is unique
       code_names <- list_db_codes(
         pool = glob$pool,
-        project_id = glob$active_project, 
+        project_id = glob$active_project,
         user = glob$user
       ) %>%
-      dplyr::filter(code_id != input$code_to_edit) %>% # exclude original name from comparison
-      dplyr::pull(code_name)
+        dplyr::filter(code_id != input$code_to_edit) %>% # exclude original name from comparison
+        dplyr::pull(code_name)
 
       # code must have a name that does not exist yet (unless it stays the same as original)
-      if (isTruthy(input$edit_code_name) && !input$edit_code_name %in% code_names) {
-        
+      if (
+        isTruthy(input$edit_code_name) && !input$edit_code_name %in% code_names
+      ) {
         # edit code
-      edit_db_codes(
-        pool = glob$pool,
-        active_project = glob$active_project,
-        user_id = glob$user$user_id,
-        edit_code_id = input$code_to_edit,
-        edit_code_name = input$edit_code_name,
-        edit_code_description = input$edit_code_desc,
-        edit_code_color = paste0(
+        edit_db_codes(
+          pool = glob$pool,
+          active_project = glob$active_project,
+          user_id = glob$user$user_id,
+          edit_code_id = input$code_to_edit,
+          edit_code_name = input$edit_code_name,
+          edit_code_description = input$edit_code_desc,
+          edit_code_color = paste0(
             "rgb(",
             paste(
               as.vector(
@@ -224,11 +265,10 @@ mod_codebook_server <- function(id, glob) {
             ),
             ")"
           )
-      )
+        )
       } else {
-       warn_user("Code names must be unique and non-empty.")
+        warn_user("Code names must be unique and non-empty.")
       }
-      
     })
 
     #---Delete existing code-------------------------------------
@@ -251,43 +291,41 @@ mod_codebook_server <- function(id, glob) {
         active_project = glob$active_project,
         user_id = glob$user$user_id,
         code_id = input$code_to_del
-        )
+      )
 
       # delete code
       delete_db_codes(
         pool = glob$pool,
         active_project = glob$active_project,
-        delete_code_id = input$code_to_del, 
+        delete_code_id = input$code_to_del,
         user_id = glob$user$user_id
       )
     })
 
-
     #---Merge codes-----------------------------------------------------
     observeEvent(input$code_merge, {
-        if (req(input$merge_from) == req(input$merge_to)) {
-          warn_user("Cannot merge a code into itself.")
-        } else {
-          merge_codes(
-            glob$pool,
-            glob$active_project,
-            req(input$merge_from),
-            req(input$merge_to), 
-            user_id = glob$user$user_id
-          )
-        }
-        })
+      if (req(input$merge_from) == req(input$merge_to)) {
+        warn_user("Cannot merge a code into itself.")
+      } else {
+        merge_codes(
+          glob$pool,
+          glob$active_project,
+          req(input$merge_from),
+          req(input$merge_to),
+          user_id = glob$user$user_id
+        )
+      }
+    })
 
-    
-   output$export_codebook <- downloadHandler(
-     filename = function() {
-       "requal_codebook.csv"
-     },
-     content = function(file) {
-       codebook <- get_codebook_export_table(glob)
-       utils::write.csv(codebook, file)
-     }
-   )
+    output$export_codebook <- downloadHandler(
+      filename = function() {
+        "requal_codebook.csv"
+      },
+      content = function(file) {
+        codebook <- get_codebook_export_table(glob)
+        utils::write.csv(codebook, file)
+      }
+    )
 
     # end of server module function
   })

--- a/R/mod_codebook.R
+++ b/R/mod_codebook.R
@@ -145,8 +145,6 @@ mod_codebook_server <- function(id, glob) {
           permission = "codebook_modify"
         )
 
-        mod_codebook_import_ui("codebook_import_1")
-
         glob$codebook <- list_db_codes(
           glob$pool,
           glob$active_project,
@@ -316,6 +314,9 @@ mod_codebook_server <- function(id, glob) {
         )
       }
     })
+
+    #---Import codebook-----------------------------------------------------
+    mod_codebook_import_server("codebook_import_1")
 
     output$export_codebook <- downloadHandler(
       filename = function() {

--- a/R/mod_codebook.R
+++ b/R/mod_codebook.R
@@ -316,7 +316,7 @@ mod_codebook_server <- function(id, glob) {
     })
 
     #---Import codebook-----------------------------------------------------
-    mod_codebook_import_server("codebook_import_1")
+    mod_codebook_import_server("codebook_import_1", glob = glob)
 
     output$export_codebook <- downloadHandler(
       filename = function() {

--- a/R/mod_codebook.R
+++ b/R/mod_codebook.R
@@ -41,6 +41,11 @@ mod_codebook_ui <- function(id) {
             icon = "minus"
           ),
           mod_rql_button_ui(
+            ns("code_export_ui"),
+            label = "Export codebook",
+            icon = "download"
+          ),
+          mod_rql_button_ui(
             ns("code_import_ui"),
             label = "Import codebook",
             icon = "upload"
@@ -64,8 +69,7 @@ mod_codebook_ui <- function(id) {
         value = "categories",
         mod_categories_ui("categories_ui_1")
       )
-    ),
-    downloadButton(ns("export_codebook"), label = "CSV")
+    )
   )
 }
 
@@ -145,6 +149,16 @@ mod_codebook_server <- function(id, glob) {
           permission = "codebook_modify"
         )
 
+        #---Export codebook UI --------------
+        mod_rql_button_server(
+          id = "code_export_ui",
+          custom_title = "Export codebook",
+          custom_tagList = downloadButton(ns("export_codebook"), label = "CSV"),
+          glob,
+          permission = TRUE
+        )
+
+        #---Codebook display --------------
         glob$codebook <- list_db_codes(
           glob$pool,
           glob$active_project,

--- a/R/mod_codebook_import.R
+++ b/R/mod_codebook_import.R
@@ -10,7 +10,25 @@
 mod_codebook_import_ui <- function(id) {
   ns <- NS(id)
   tagList(
-    "test"
+    fileInput(
+      ns("file"),
+      "Choose CSV File",
+      accept = c(
+        "text/csv",
+        "text/comma-separated-values,text/plain",
+        ".csv"
+      )
+    ),
+    tags$hr(),
+    checkboxInput(ns("header"), "Header", TRUE),
+    radioButtons(
+      ns("sep"),
+      "Separator",
+      choices = c(Comma = ",", Semicolon = ";", Tab = "\t"),
+      selected = ","
+    ),
+    actionButton(ns("import"), "Import"),
+    tableOutput(ns("contents")) # Ensure the table output is included in the UI
   )
 }
 
@@ -20,6 +38,170 @@ mod_codebook_import_ui <- function(id) {
 mod_codebook_import_server <- function(id) {
   moduleServer(id, function(input, output, session) {
     ns <- session$ns
+    loc <- reactiveValues()
+
+    observeEvent(input$import, {
+      req(input$file)
+      loc$input_df <- read.csv(
+        input$file$datapath,
+        header = input$header,
+        sep = input$sep
+      )
+      loc$available_colnames <- colnames(loc$input_df)
+      loc$used_colnames <- NA
+      # Initialize the imported_df with blank columns
+      loc$imported_df <- tibble::tibble(
+        `Code name` = "",
+        `Code description` = "",
+        `Code color` = ""
+      )
+
+      showModal(modalDialog(
+        title = "Map imported columns",
+        selectInput(
+          ns("code_name"),
+          "Select column for code name",
+          choices = c(
+            "",
+            setdiff(
+              colnames(loc$input_df),
+              c(input$code_description, input$code_color)
+            )
+          ),
+          selected = ""
+        ),
+        selectInput(
+          ns("code_description"),
+          "Select column for code description",
+          choices = c(
+            "",
+            setdiff(
+              colnames(loc$input_df),
+              c(input$code_name, input$code_color)
+            )
+          ),
+          selected = ""
+        ),
+        selectInput(
+          ns("code_color"),
+          "Select column for code color",
+          choices = c(
+            "",
+            setdiff(
+              colnames(loc$input_df),
+              c(input$code_name, input$code_description)
+            )
+          ),
+          selected = ""
+        ),
+        "Preview",
+        DT::dataTableOutput(ns("preview")),
+        footer = tagList(
+          modalButton("Cancel"),
+          actionButton(ns("confirm"), "Confirm")
+        )
+      ))
+    })
+    observeEvent(c(input$code_name, input$code_description, input$code_color), {
+      updateSelectInput(
+        session,
+        "code_name",
+        selected = input$code_name,
+        choices = c(
+          "",
+          setdiff(
+            colnames(loc$input_df),
+            c(input$code_color, input$code_description)
+          )
+        )
+      )
+
+      updateSelectInput(
+        session,
+        "code_description",
+        selected = input$code_description,
+
+        choices = c(
+          "",
+          setdiff(
+            colnames(loc$input_df),
+            c(input$code_name, input$code_color)
+          )
+        )
+      )
+
+      updateSelectInput(
+        session,
+        "code_color",
+        selected = input$code_color,
+        choices = c(
+          "",
+          setdiff(
+            colnames(loc$input_df),
+            c(input$code_name, input$code_description)
+          )
+        )
+      )
+    })
+
+    # Render preview of the data frame with selected columns
+    output$preview <- DT::renderDT({
+      req(input$code_name)
+
+      # Initialize a list to store selected columns
+      selected_columns <- input$code_name
+
+      # Conditionally add optional columns if they are specified
+      if (isTruthy(input$code_description)) {
+        selected_columns <- c(selected_columns, input$code_description)
+      }
+      if (isTruthy(input$code_color)) {
+        selected_columns <- c(selected_columns, input$code_color)
+      }
+
+      # Select the specified columns from the data frame
+      preview_df <- loc$input_df %>%
+        dplyr::select(all_of(selected_columns))
+
+      # Truncate the code description if it is part of the selected columns
+      if (input$code_description %in% selected_columns) {
+        preview_df <- preview_df %>%
+          dplyr::mutate(
+            !!input$code_description := stringr::str_trunc(
+              .data[[input$code_description]],
+              width = 30,
+              side = "right",
+              ellipsis = "..."
+            )
+          )
+      }
+
+      # Render the datatable
+      datatable <- DT::datatable(
+        preview_df,
+        escape = FALSE,
+        options = list(dom = 't', ordering = FALSE)
+      )
+
+      # Apply color formatting if 'Code color' is part of the selected columns
+      if (input$code_color %in% selected_columns) {
+        datatable <- datatable %>%
+          DT::formatStyle(
+            input$code_color,
+            backgroundColor = DT::styleEqual(
+              unique(preview_df[[input$code_color]]),
+              unique(preview_df[[input$code_color]])
+            )
+          )
+      }
+
+      datatable
+    })
+
+    observeEvent(input$confirm, {
+      removeModal()
+      # Final processing of the data frame can be done here
+    })
   })
 }
 

--- a/R/mod_codebook_import.R
+++ b/R/mod_codebook_import.R
@@ -1,0 +1,30 @@
+#' codebook_import UI Function
+#'
+#' @description A shiny Module.
+#'
+#' @param id,input,output,session Internal parameters for {shiny}.
+#'
+#' @noRd
+#'
+#' @importFrom shiny NS tagList
+mod_codebook_import_ui <- function(id) {
+  ns <- NS(id)
+  tagList(
+    "test"
+  )
+}
+
+#' codebook_import Server Functions
+#'
+#' @noRd
+mod_codebook_import_server <- function(id) {
+  moduleServer(id, function(input, output, session) {
+    ns <- session$ns
+  })
+}
+
+## To be copied in the UI
+# mod_codebook_import_ui("codebook_import_1")
+
+## To be copied in the server
+# mod_codebook_import_server("codebook_import_1")

--- a/R/mod_codebook_import.R
+++ b/R/mod_codebook_import.R
@@ -46,6 +46,7 @@ mod_codebook_import_server <- function(id, glob) {
     ns <- session$ns
     loc <- reactiveValues()
 
+    # Load import file -----
     observeEvent(input$import, {
       req(input$file)
       loc$input_df <- read.csv(
@@ -54,6 +55,7 @@ mod_codebook_import_server <- function(id, glob) {
         sep = input$sep
       )
 
+      # Import wizard -----
       # This pop-up modal serves as an import wizard
       showModal(modalDialog(
         title = "Specify imported codes",
@@ -98,7 +100,7 @@ mod_codebook_import_server <- function(id, glob) {
         DT::dataTableOutput(ns("preview")),
         footer = tagList(
           modalButton("Cancel"),
-          actionButton(ns("confirm"), "Confirm")
+          shinyjs::disabled(actionButton(ns("confirm"), "Confirm"))
         )
       ))
     })
@@ -106,6 +108,12 @@ mod_codebook_import_server <- function(id, glob) {
     # This observer ensures that column names available to user
     # are updating so that no column can be selected twice
     observeEvent(c(input$code_name, input$code_description, input$code_color), {
+      if (isTruthy(input$code_name)) {
+        shinyjs::enable("confirm")
+      } else {
+        shinyjs::disable("confirm")
+      }
+
       updateSelectInput(
         session,
         "code_name",
@@ -147,6 +155,7 @@ mod_codebook_import_server <- function(id, glob) {
       )
     })
 
+    # Processing imported df -----
     observeEvent(c(input$code_name, input$code_description, input$code_color), {
       req(input$code_name)
 
@@ -245,6 +254,7 @@ mod_codebook_import_server <- function(id, glob) {
       datatable
     })
 
+    # Import execute -----
     observeEvent(input$confirm, {
       removeModal()
       # Writing imported codes to database
@@ -312,12 +322,7 @@ mod_codebook_import_server <- function(id, glob) {
   })
 }
 
-## To be copied in the UI
-# mod_codebook_import_ui("codebook_import_1")
-
-## To be copied in the server
-# mod_codebook_import_server("codebook_import_1")
-
+# Helper function for this module -----
 convert_to_rgb <- function(color) {
   # Check if the color is a vector of three numeric values first
   if (

--- a/R/mod_codebook_import.R
+++ b/R/mod_codebook_import.R
@@ -222,6 +222,10 @@ convert_to_rgb <- function(color) {
     return(paste0("rgb(", paste(color, collapse = ", "), ")"))
   }
 
+  if(color %in% grDevices::colors()){
+    return(paste0("rgb(", paste0(grDevices::col2rgb(color)[, 1], collapse = ", "), ")"))
+  }
+
   # Ensure color is a character string for regex operations
   if (!is.character(color) || length(color) != 1) {
     return(FALSE)
@@ -265,7 +269,7 @@ convert_to_rgb <- function(color) {
   }
 
   # If no format is matched, return FALSE
-  return(NA)
+  return(NA_character_)
 }
 
 
@@ -312,7 +316,7 @@ process_color_column <- function(df, color_col_name) {
       rql_message(
         "Could not identify colors in the selected column. Resorting to default."
       )
-      df[[color_col_name]] <- "rgb(255,255,0)"
+      df[[color_col_name]][is.na(df[[color_col_name]])] <- "rgb(255, 255, 0)"
     }
   }
   return(df)

--- a/R/mod_codebook_import.R
+++ b/R/mod_codebook_import.R
@@ -46,7 +46,7 @@ mod_codebook_import_server <- function(id, glob) {
     ns <- session$ns
     loc <- reactiveValues()
 
-    # Load import file -----
+    # Load import file
     observeEvent(input$import, {
       req(input$file)
       loc$input_df <- read.csv(
@@ -54,192 +54,50 @@ mod_codebook_import_server <- function(id, glob) {
         header = input$header,
         sep = input$sep
       )
-
-      # Import wizard -----
-      # This pop-up modal serves as an import wizard
-      showModal(modalDialog(
-        title = "Specify imported codes",
-        selectInput(
-          ns("code_name"),
-          "Select column for code name",
-          choices = c(
-            "",
-            setdiff(
-              colnames(loc$input_df),
-              c(input$code_description, input$code_color)
-            )
-          ),
-          selected = ""
-        ) %>%
-          tagAppendAttributes(class = "required"),
-        selectInput(
-          ns("code_description"),
-          "Select column for code description",
-          choices = c(
-            "",
-            setdiff(
-              colnames(loc$input_df),
-              c(input$code_name, input$code_color)
-            )
-          ),
-          selected = ""
-        ),
-        selectInput(
-          ns("code_color"),
-          "Select column for code color",
-          choices = c(
-            "",
-            setdiff(
-              colnames(loc$input_df),
-              c(input$code_name, input$code_description)
-            )
-          ),
-          selected = ""
-        ),
-        "Preview",
-        DT::dataTableOutput(ns("preview")),
-        footer = tagList(
-          modalButton("Cancel"),
-          shinyjs::disabled(actionButton(ns("confirm"), "Confirm"))
-        )
-      ))
+      show_import_wizard()
     })
 
-    # This observer ensures that column names available to user
-    # are updating so that no column can be selected twice
+    # Update column choices when selections change
     observeEvent(c(input$code_name, input$code_description, input$code_color), {
       if (isTruthy(input$code_name)) {
         shinyjs::enable("confirm")
       } else {
         shinyjs::disable("confirm")
       }
-
-      updateSelectInput(
-        session,
-        "code_name",
-        selected = input$code_name,
-        choices = c(
-          "",
-          setdiff(
-            colnames(loc$input_df),
-            c(input$code_color, input$code_description)
-          )
-        )
-      )
-
-      updateSelectInput(
-        session,
-        "code_description",
-        selected = input$code_description,
-
-        choices = c(
-          "",
-          setdiff(
-            colnames(loc$input_df),
-            c(input$code_name, input$code_color)
-          )
-        )
-      )
-
-      updateSelectInput(
-        session,
-        "code_color",
-        selected = input$code_color,
-        choices = c(
-          "",
-          setdiff(
-            colnames(loc$input_df),
-            c(input$code_name, input$code_description)
-          )
-        )
-      )
+      update_all_selectors()
     })
 
-    # Processing imported df -----
+    # Process imported dataframe
     observeEvent(c(input$code_name, input$code_description, input$code_color), {
       req(input$code_name)
 
-      # Initialize a vector of selected columns
-      selected_columns <- input$code_name
+      selected_columns <- build_selected_columns(
+        input$code_name,
+        input$code_description,
+        input$code_color
+      )
 
-      # Conditionally add optional columns if they are specified
-      if (isTruthy(input$code_description)) {
-        selected_columns <- c(selected_columns, input$code_description)
-      }
-      if (isTruthy(input$code_color)) {
-        selected_columns <- c(selected_columns, input$code_color)
-      }
-
-      # Create and process preview dataframe
       loc$output_df <- loc$input_df %>%
-        dplyr::select(all_of(selected_columns))
-
-      # modify preview if needed
-      # display ellipses for long code descriptions
-      if (
-        isTruthy(input$code_description) &&
-          input$code_description %in% selected_columns
-      ) {
-        loc$output_df[[input$code_description]] <- stringr::str_trunc(
-          loc$output_df[[input$code_description]],
-          width = 30,
-          side = "right",
-          ellipsis = "..."
+        dplyr::select(all_of(selected_columns)) %>%
+        process_description_column(input$code_description) %>%
+        process_color_column(input$code_color) %>%
+        rename_columns_to_standard(
+          input$code_name,
+          input$code_description,
+          input$code_color
         )
-      }
-      # modify preview if needed
-      # check and convert code colors
-      if (
-        isTruthy(input$code_color) &&
-          input$code_color %in% selected_columns
-      ) {
-        loc$output_df[[input$code_color]] <- purrr::map_chr(
-          loc$output_df[[input$code_color]],
-          convert_to_rgb
-        )
-
-        if (any(is.na(loc$output_df[[input$code_color]]))) {
-          rql_message(
-            "Could not identify colors in the selected column. Resorting to default."
-          )
-          loc$output_df[[input$code_color]] <- "rgb(255,255,0)"
-        }
-      }
-
-      # Map original column names to display names
-      if (input$code_name %in% names(loc$output_df)) {
-        names(loc$output_df)[which(
-          names(loc$output_df) == input$code_name
-        )] <- "Code name"
-      }
-      if (
-        isTruthy(input$code_description) &&
-          input$code_description %in% names(loc$output_df)
-      ) {
-        names(loc$output_df)[which(
-          names(loc$output_df) == input$code_description
-        )] <- "Code description"
-      }
-      if (
-        isTruthy(input$code_color) &&
-          input$code_color %in% names(loc$output_df)
-      ) {
-        names(loc$output_df)[which(
-          names(loc$output_df) == input$code_color
-        )] <- "Code color"
-      }
     })
 
     # Render the datatable
     output$preview <- DT::renderDT({
-      # The preview should not be generated if code_name is not supplied
       req(input$code_name)
+
       datatable <- DT::datatable(
         head(loc$output_df),
         escape = FALSE,
         options = list(dom = 't', ordering = FALSE)
       )
-      # Apply color styling if needed (use new column name)
+
       if (
         isTruthy(input$code_color) && "Code color" %in% names(loc$output_df)
       ) {
@@ -250,75 +108,108 @@ mod_codebook_import_server <- function(id, glob) {
             backgroundColor = DT::styleEqual(unique_colors, unique_colors)
           )
       }
-      # render datatable
+
       datatable
     })
 
-    # Import execute -----
+    # Import execute
     observeEvent(input$confirm, {
       removeModal()
-      # Writing imported codes to database
-      # check if code names are unique
 
-      # Get the saved and imported code names
-      code_names_saved <- list_db_codes(
+      # Get existing codes
+      existing_codes <- list_db_codes(
         pool = glob$pool,
         project_id = glob$active_project,
         user = glob$user
       )$code_name
 
-      code_names_imported <- as.character(loc$output_df[["Code name"]])
-
-      # Check for conflicts and duplications
-      conflict_exists <- any(code_names_imported %in% code_names_saved)
-      duplication_exists <- any(duplicated(code_names_imported))
-
-      if (conflict_exists || duplication_exists) {
-        warn_user(
-          "Conflicting or duplicate code names found. Code names should be unique."
+      # Validate and import
+      if (validate_code_names(loc$output_df, existing_codes)) {
+        imported_df <- prepare_import_dataframe(
+          loc$output_df,
+          glob$active_project,
+          glob$user$user_id
         )
-        req(FALSE) # abort if not unique
-      }
 
-      # If unique check passed, proceed with writing to database
-      if ("Code description" %in% names(loc$output_df)) {
-        code_description <- loc$output_df[["Code description"]]
-      } else {
-        code_description <- NA
+        import_codes_to_database(
+          imported_df,
+          glob$pool,
+          glob$active_project,
+          glob$user$user_id
+        )
+
+        # Update global state
+        glob$codebook <- list_db_codes(
+          glob$pool,
+          glob$active_project,
+          glob$user
+        )
+        glob$codebook_observer <- glob$codebook_observer + 1
       }
-      if ("Code color" %in% names(loc$output_df)) {
-        code_color <- loc$output_df[["Code color"]]
-      } else {
-        code_color <- "rgb(255,255,0)"
-      }
-      imported_df <- data.frame(
-        project_id = glob$active_project,
-        code_name = code_names_imported,
-        code_description = code_description,
-        code_color = code_color,
-        user_id = glob$user$user_id
+    })
+
+    # Internal helper functions (need access to input, session, loc, or ns) ----
+    get_column_choices_for <- function(field) {
+      exclude_cols <- switch(
+        field,
+        "code_name" = c(input$code_description, input$code_color),
+        "code_description" = c(input$code_name, input$code_color),
+        "code_color" = c(input$code_name, input$code_description)
       )
+      get_column_choices_excluding(colnames(loc$input_df), exclude_cols)
+    }
 
-      # Split the data frame into a list of one-row data frames
-      rows_list <- split(imported_df, seq(nrow(imported_df)))
-      # Iterate over each one-row data frame
-      purrr::map(rows_list, function(row_df) {
-        add_codes_record(
-          pool = glob$pool,
-          project_id = glob$active_project,
-          codes_df = row_df, # Pass the one-row data frame
-          user_id = glob$user$user_id
+    show_import_wizard <- function() {
+      showModal(modalDialog(
+        title = "Specify imported codes",
+        create_column_selectors(),
+        "Preview",
+        DT::dataTableOutput(ns("preview")),
+        footer = tagList(
+          modalButton("Cancel"),
+          shinyjs::disabled(actionButton(ns("confirm"), "Confirm"))
+        )
+      ))
+    }
+
+    create_column_selectors <- function() {
+      tagList(
+        selectInput(
+          ns("code_name"),
+          "Select column for code name",
+          choices = get_column_choices_for("code_name"),
+          selected = ""
+        ) %>%
+          tagAppendAttributes(class = "required"),
+
+        selectInput(
+          ns("code_description"),
+          "Select column for code description",
+          choices = get_column_choices_for("code_description"),
+          selected = ""
+        ),
+
+        selectInput(
+          ns("code_color"),
+          "Select column for code color",
+          choices = get_column_choices_for("code_color"),
+          selected = ""
+        )
+      )
+    }
+
+    update_all_selectors <- function() {
+      selectors <- c("code_name", "code_description", "code_color")
+
+      purrr::walk(selectors, function(selector) {
+        updateSelectInput(
+          session,
+          selector,
+          selected = input[[selector]],
+          choices = get_column_choices_for(selector)
         )
       })
-      # update codebook
-      glob$codebook <- list_db_codes(
-        glob$pool,
-        glob$active_project,
-        glob$user
-      )
-      # update codebook observer
-      glob$codebook_observer <- glob$codebook_observer + 1
-    })
+    }
   })
 }
 
@@ -375,4 +266,124 @@ convert_to_rgb <- function(color) {
 
   # If no format is matched, return FALSE
   return(NA)
+}
+
+
+get_column_choices_excluding <- function(df_cols, exclude_cols) {
+  c("", setdiff(df_cols, exclude_cols))
+}
+
+build_selected_columns <- function(
+  code_name,
+  code_description = NULL,
+  code_color = NULL
+) {
+  columns <- code_name
+  if (isTruthy(code_description)) {
+    columns <- c(columns, code_description)
+  }
+  if (isTruthy(code_color)) {
+    columns <- c(columns, code_color)
+  }
+  return(columns)
+}
+
+process_description_column <- function(df, description_col_name) {
+  if (isTruthy(description_col_name) && description_col_name %in% names(df)) {
+    df[[description_col_name]] <- stringr::str_trunc(
+      df[[description_col_name]],
+      width = 30,
+      side = "right",
+      ellipsis = "..."
+    )
+  }
+  return(df)
+}
+
+process_color_column <- function(df, color_col_name) {
+  if (isTruthy(color_col_name) && color_col_name %in% names(df)) {
+    df[[color_col_name]] <- purrr::map_chr(
+      df[[color_col_name]],
+      convert_to_rgb
+    )
+
+    # Handle invalid colors
+    if (any(is.na(df[[color_col_name]]))) {
+      rql_message(
+        "Could not identify colors in the selected column. Resorting to default."
+      )
+      df[[color_col_name]] <- "rgb(255,255,0)"
+    }
+  }
+  return(df)
+}
+
+rename_columns_to_standard <- function(
+  df,
+  code_name,
+  code_description = NULL,
+  code_color = NULL
+) {
+  column_mappings <- list(
+    list(old = code_name, new = "Code name"),
+    list(old = code_description, new = "Code description"),
+    list(old = code_color, new = "Code color")
+  )
+
+  for (mapping in column_mappings) {
+    if (isTruthy(mapping$old) && mapping$old %in% names(df)) {
+      names(df)[which(names(df) == mapping$old)] <- mapping$new
+    }
+  }
+  return(df)
+}
+
+validate_code_names <- function(output_df, existing_codes) {
+  code_names_imported <- as.character(output_df[["Code name"]])
+
+  conflict_exists <- any(code_names_imported %in% existing_codes)
+  duplication_exists <- any(duplicated(code_names_imported))
+
+  if (conflict_exists || duplication_exists) {
+    warn_user(
+      "Conflicting or duplicate code names found. Code names should be unique."
+    )
+    return(FALSE)
+  }
+  return(TRUE)
+}
+
+prepare_import_dataframe <- function(output_df, project_id, user_id) {
+  # Extract values with defaults
+  code_description <- if ("Code description" %in% names(output_df)) {
+    output_df[["Code description"]]
+  } else {
+    NA
+  }
+
+  code_color <- if ("Code color" %in% names(output_df)) {
+    output_df[["Code color"]]
+  } else {
+    "rgb(255,255,0)"
+  }
+
+  data.frame(
+    project_id = project_id,
+    code_name = as.character(output_df[["Code name"]]),
+    code_description = code_description,
+    code_color = code_color,
+    user_id = user_id
+  )
+}
+
+import_codes_to_database <- function(imported_df, pool, project_id, user_id) {
+  split(imported_df, seq(nrow(imported_df))) %>%
+    purrr::walk(function(row_df) {
+      add_codes_record(
+        pool = pool,
+        project_id = project_id,
+        codes_df = row_df,
+        user_id = user_id
+      )
+    })
 }

--- a/R/mod_codebook_utils_codebook.R
+++ b/R/mod_codebook_utils_codebook.R
@@ -319,6 +319,12 @@ merge_codes <- function(pool,
     log_merge_code_record(pool, project_id = active_project, merge_from, merge_to, user_id)
 }
 
+# convert color to hex code
+convert_colour_to_hex <- function(color){
+    col_num <- as.numeric(stringr::str_extract_all(color, "[0-9]{1,3}", simplify = TRUE))
+    grDevices::rgb(red = col_num[1], green = col_num[2], blue = col_num[3], maxColorValue = 255)
+}
+
 # prepare data.frame with codes and categories to export
 get_codebook_export_table <- function(glob){
     categories <- dplyr::tbl(glob$pool, "categories") %>% 
@@ -336,8 +342,9 @@ get_codebook_export_table <- function(glob){
         dplyr::inner_join(categories, by = "category_id") 
     
     dplyr::left_join(glob$codebook, categories_map, by = "code_id") %>% 
-        dplyr::group_by(code_id, code_name, code_description) %>% 
-        dplyr::summarise(categories = paste0(category_title, collapse = " | "))
+        dplyr::group_by(code_id, code_name, code_description, code_color) %>% 
+        dplyr::summarise(categories = paste0(category_title, collapse = " | ")) %>%
+        dplyr::mutate(code_color = purrr::map_chr(code_color, convert_colour_to_hex))
 }
 
 # Edit codes ------

--- a/dev/02_dev.R
+++ b/dev/02_dev.R
@@ -1,12 +1,12 @@
 # Building a Prod-Ready, Robust Shiny Application.
-# 
-# README: each step of the dev files is optional, and you don't have to 
-# fill every dev scripts before getting started. 
-# 01_start.R should be filled at start. 
+#
+# README: each step of the dev files is optional, and you don't have to
+# fill every dev scripts before getting started.
+# 01_start.R should be filled at start.
 # 02_dev.R should be used to keep track of your development during the project.
 # 03_deploy.R should be used once you need to deploy your app.
-# 
-# 
+#
+#
 ###################################
 #### CURRENT FILE: DEV SCRIPT #####
 ###################################
@@ -15,102 +15,108 @@
 
 ## Dependencies ----
 ## Add one line by package you want to add as dependency
-usethis::use_package( "rlang" )
-usethis::use_package( "shinydashboardPlus" )
-usethis::use_package( "shinyFiles" )
-usethis::use_package( "shinyjs" )
-usethis::use_package( "colourpicker")
-usethis::use_package( "DBI" )
-usethis::use_package( "RSQLite" )
-usethis::use_package( "dplyr" )
-usethis::use_package( "tibble" )
-usethis::use_package( "magrittr" )
-usethis::use_package( "dbplyr" )
-usethis::use_package( "purrr" )
-usethis::use_package( "stringr" )
-usethis::use_package( "htmlwidgets" )
-usethis::use_package( "sortable" )
-usethis::use_package( "shinyWidgets" )
-usethis::use_package( "RPostgreSQL" )
-usethis::use_package( "shinymanager" )
-usethis::use_package( "pool" )
+usethis::use_package("rlang")
+usethis::use_package("shinydashboardPlus")
+usethis::use_package("shinyFiles")
+usethis::use_package("shinyjs")
+usethis::use_package("colourpicker")
+usethis::use_package("DBI")
+usethis::use_package("RSQLite")
+usethis::use_package("dplyr")
+usethis::use_package("tibble")
+usethis::use_package("magrittr")
+usethis::use_package("dbplyr")
+usethis::use_package("purrr")
+usethis::use_package("stringr")
+usethis::use_package("htmlwidgets")
+usethis::use_package("sortable")
+usethis::use_package("shinyWidgets")
+usethis::use_package("RPostgreSQL")
+usethis::use_package("shinymanager")
+usethis::use_package("pool")
 
 
 ## Add modules ----
 ## Create a module infrastructure in R/
-golem::add_module( name = "launchpad_loader" ) # Name of the module
-golem::add_module( name = "launchpad_creator" ) # Name of the module
+golem::add_module(name = "launchpad_loader") # Name of the module
+golem::add_module(name = "launchpad_creator") # Name of the module
 
 # Project menu
-golem::add_module( name = "project" ) # Name of the module
-golem::add_module( name = "user_manager" ) # Name of the module
+golem::add_module(name = "project") # Name of the module
+golem::add_module(name = "user_manager") # Name of the module
 
 # Data menu
-golem::add_module( name = "data" ) # Name of the module
-golem::add_module( name = "doc_manager" ) # Name of the module
-golem::add_module( name = "cases_manager" ) # Name of the module
+golem::add_module(name = "data") # Name of the module
+golem::add_module(name = "doc_manager") # Name of the module
+golem::add_module(name = "cases_manager") # Name of the module
 
 # Attributes menu
-golem::add_module( name = "attributes" ) # Name of the module
-golem::add_module( name = "attributes_manager" ) # Name of the module
+golem::add_module(name = "attributes") # Name of the module
+golem::add_module(name = "attributes_manager") # Name of the module
 
 
 # Codebook menu
-golem::add_module( name = "codebook" ) # Name of the module
-golem::add_module( name = "categories" ) # Name of the module
+golem::add_module(name = "codebook") # Name of the module
+golem::add_module(name = "categories") # Name of the module
 
 
 # Coding workspace
-golem::add_module( name = "document_code" ) # Name of the module
+golem::add_module(name = "document_code") # Name of the module
 
 
 # Analysis
-golem::add_module( name = "analysis" ) # Name of the module
-golem::add_module( name = "download_handler" ) # Name of the module
-golem::add_module( name = "download_html" ) # Name of the module
+golem::add_module(name = "analysis") # Name of the module
+golem::add_module(name = "download_handler") # Name of the module
+golem::add_module(name = "download_html") # Name of the module
 
 
-golem::add_module( name = "reporting" ) # Name of the module
-golem::add_module( name = "settings" ) # Name of the module
-golem::add_module( name = "about" ) # Name of the module
-golem::add_module( name = "user" ) # Name of the module
-golem::add_module( name = "memo" ) # Name of the module
-golem::add_module( name = "agreement" )
-golem::add_module( name = "browser" )
-golem::add_module( name = "text_stats")
-golem::add_module( name = "summary" )
-golem::add_module( name = "rql_button" )
+golem::add_module(name = "reporting") # Name of the module
+golem::add_module(name = "settings") # Name of the module
+golem::add_module(name = "about") # Name of the module
+golem::add_module(name = "user") # Name of the module
+golem::add_module(name = "memo") # Name of the module
+golem::add_module(name = "agreement")
+golem::add_module(name = "browser")
+golem::add_module(name = "text_stats")
+golem::add_module(name = "summary")
+golem::add_module(name = "rql_button")
+golem::add_module(name = "rql_hidden_ui")
+golem::add_module(name = "memo_segment")
+golem::add_module(name = "memo_editor")
+golem::add_module(name = "codebook_import")
 
 
 ## Add helper functions ----
 ## Creates fct_* and utils_*
-golem::add_fct( "helpers" ) 
-golem::add_utils( "project", module = "project" )
-golem::add_utils( "codebook", module = "codebook" )
-golem::add_utils( "categories", module = "categories" )
-golem::add_utils( "document_code", module = "document_code" )
-golem::add_utils( "doc_manager", module = "doc_manager" )
-golem::add_utils( "analysis", module = "analysis" )
-golem::add_utils( "reporting", module = "reporting" )
-golem::add_utils( "user", module = "user" )
-golem::add_utils( "memo", module = "memo" )
-golem::add_utils( "agreement", module = "agreement" )
-golem::add_utils( "text_stats", module = "agreement" )
-golem::add_utils( "browser", module = "browser" )
-golem::add_utils( "user_manager", module = "user_manager" )
-
+golem::add_fct("helpers")
+golem::add_utils("project", module = "project")
+golem::add_utils("codebook", module = "codebook")
+golem::add_utils("categories", module = "categories")
+golem::add_utils("document_code", module = "document_code")
+golem::add_utils("doc_manager", module = "doc_manager")
+golem::add_utils("analysis", module = "analysis")
+golem::add_utils("reporting", module = "reporting")
+golem::add_utils("user", module = "user")
+golem::add_utils("memo", module = "memo")
+golem::add_utils("agreement", module = "agreement")
+golem::add_utils("text_stats", module = "agreement")
+golem::add_utils("browser", module = "browser")
+golem::add_utils("user_manager", module = "user_manager")
 
 
 ## External resources
 ## Creates .js and .css files at inst/app/www
-golem::add_js_file( "document_code_js" )
-golem::add_js_file( "check_categories" )
-golem::add_js_handler( "handlers" )
-golem::add_css_file( "custom" )
+golem::add_js_file("document_code_js")
+golem::add_js_file("check_categories")
+golem::add_js_handler("handlers")
+golem::add_css_file("custom")
+golem::add_css_file("memo_editor")
+golem::add_js_file("memo_editor")
+
 
 ## Add internal datasets ----
 ## If you have data in your package
-# usethis::use_data_raw( name = "my_dataset", open = FALSE ) 
+# usethis::use_data_raw( name = "my_dataset", open = FALSE )
 
 ## Tests ----
 ## Add one line by test you want to create
@@ -132,26 +138,26 @@ usethis::use_coverage()
 ## CI ----
 ## Use this part of the script if you need to set up a CI
 ## service for your application
-## 
+##
 ## (You'll need GitHub there)
 usethis::use_github()
 
 # GitHub Actions
-usethis::use_github_action() 
+usethis::use_github_action()
 # Chose one of the three
 # See https://usethis.r-lib.org/reference/use_github_action.html
-usethis::use_github_action_check_release() 
-usethis::use_github_action_check_standard() 
-usethis::use_github_action_check_full() 
+usethis::use_github_action_check_release()
+usethis::use_github_action_check_standard()
+usethis::use_github_action_check_full()
 # Add action for PR
 usethis::use_github_action_pr_commands()
 
 # Travis CI
-usethis::use_travis() 
-usethis::use_travis_badge() 
+usethis::use_travis()
+usethis::use_travis_badge()
 
-# AppVeyor 
-usethis::use_appveyor() 
+# AppVeyor
+usethis::use_appveyor()
 usethis::use_appveyor_badge()
 
 # Circle CI
@@ -167,4 +173,3 @@ usethis::use_gitlab_ci()
 # You're now set! ----
 # go to dev/03_deploy.R
 rstudioapi::navigateToFile("dev/03_deploy.R")
-

--- a/tests/testthat/test-codebook-import.R
+++ b/tests/testthat/test-codebook-import.R
@@ -1,0 +1,21 @@
+test_that("Test parsing color to RGB works", {
+    expect_equal(convert_to_rgb("#FF0000"), "rgb(255, 0, 0)")
+    expect_equal(convert_to_rgb("#F00"), "rgb(255, 0, 0)")
+    expect_equal(convert_to_rgb("red"), "rgb(255, 0, 0)")
+    expect_equal(convert_to_rgb("gred"), NA_character_)
+})
+
+color_df <- data.frame(
+  color = c("#FF0000", "#F00", "red", "gred")
+)
+
+output_color_df <- data.frame(
+  color = c("rgb(255, 0, 0)", "rgb(255, 0, 0)", "rgb(255, 0, 0)", "rgb(255, 255, 0)")
+)
+
+test_that("Test parsing color to RGB works with data frame", {
+    expect_equal(
+      process_color_column(color_df, "color"), 
+      output_color_df  
+    )
+})


### PR DESCRIPTION
As requested in #161.
New (sub)module to import codebooks from rectangular format (CSV/TSV) files.
Relies on a modal wizard, which gives users some leeway in how their import file is formatted.
Includes basic checks such as properly specified colors or unique code names.

At present, the following is supported:
- code name (required)
- code description (optional)
- code color (optional) 

Although this works and can be useful for some use cases, I think we need further steps to consider this feature complete:
- parsing categories
- include code color in Requal codebook export 

These extensions will enable complete circulation of Requal codebooks via CSVs.

Also, when supported by Requal, we need to implement the following:
- parsing code paths for code hierarchy