### PR TITLE
Fix 177 (Requal crashing on Windows 11)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: requal
 Title: Shiny Application for Computer-Assisted Qualitative Data Analysis
-Version: 1.2.4.9006
+Version: 1.2.4.9007
 Authors@R:
     c(
      person(given = "Radim",

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,6 +25,7 @@
   - default document encoding is now processed explicitly
   - other minor fixes
   - selecting segments on smartphones/tablets and by combination of mouse and keyboard now works
+  - Requal crashing on Windows 11 due to missing wmic utility
 
 # requal 1.1.3 Rieppeleon
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -193,7 +193,7 @@ get_volume_paths <- function() {
     names(volumes_checked) <- volumes_checked
     volumes_checked
   } else if (tolower(sysinfo["sysname"]) == "windows") {
-    # First try PowerShell
+    # For Windows 11, first try PowerShell
     tryCatch(
       {
         volumes_string <- system(

--- a/R/utils.R
+++ b/R/utils.R
@@ -193,11 +193,46 @@ get_volume_paths <- function() {
     names(volumes_checked) <- volumes_checked
     volumes_checked
   } else if (tolower(sysinfo["sysname"]) == "windows") {
-    volumes_string <- system("wmic logicaldisk get caption", intern = TRUE)
-    volumes <- unlist(stringr::str_extract_all(volumes_string, "[A-Z]\\:"))
-    volumes_checked <- volumes[fs::file_access(volumes)]
-    names(volumes_checked) <- volumes_checked
-    volumes_checked
+    # First try PowerShell
+    tryCatch(
+      {
+        volumes_string <- system(
+          "powershell -Command \"Get-PSDrive -PSProvider FileSystem | Select-Object -ExpandProperty Name\"",
+          intern = TRUE
+        )
+        volumes <- paste0(volumes_string[nzchar(volumes_string)], ":")
+        volumes_checked <- volumes[fs::file_access(volumes)]
+        names(volumes_checked) <- volumes_checked
+        volumes_checked
+      },
+      error = function(e) {
+        # Fallback: try wmic
+        tryCatch(
+          {
+            volumes_string <- system(
+              "wmic logicaldisk get caption",
+              intern = TRUE
+            )
+            volumes <- unlist(stringr::str_extract_all(
+              volumes_string,
+              "[A-Z]\\:"
+            ))
+            volumes_checked <- volumes[fs::file_access(volumes)]
+            names(volumes_checked) <- volumes_checked
+            volumes_checked
+          },
+          error = function(e2) {
+            # Last resort: check common drive letters
+            potential_volumes <- paste0(LETTERS[3:26], ":") # C: through Z:
+            volumes_checked <- potential_volumes[fs::file_access(
+              potential_volumes
+            )]
+            names(volumes_checked) <- volumes_checked
+            volumes_checked
+          }
+        )
+      }
+    )
   } else {
     c(Volumes = fs::path_home())
   }


### PR DESCRIPTION
Fix for missing wmic utility on Windows 11 OS - try using PowerShell before falling back on wmic.